### PR TITLE
Add new hook: before_logger

### DIFF
--- a/src/transmogrifier_ploneblueprints/pipelines/plone.import.content.cfg
+++ b/src/transmogrifier_ploneblueprints/pipelines/plone.import.content.cfg
@@ -50,6 +50,7 @@ pipeline =
     plone.import.content.pathprefix
     plone.import.content.pathresolve
 
+    plone.import.content.before_logger
     plone.import.content.logger
 
     plone.import.content.fix_dublincore
@@ -121,6 +122,9 @@ _path = '${transmogrifier:prefix}' + item['_path']
 
 [plone.import.content.pathresolve]
 blueprint = plone.uuid.path_from_uuid
+
+[plone.import.content.before_logger]
+blueprint = transmogrifier.pipeline
 
 [plone.import.content.logger]
 blueprint = transmogrifier.logger


### PR DESCRIPTION
This can be used for example to filter before logging, before
the target system is actually modified, and so that the run
output only logs items that are actually processed.

If using before_commit as a filter stage, it doesn't indicate
the skip on the output in any way.

Better aproach could be to modify the filters to output a custom
a message whin filter hits, but this was way more straightforward.